### PR TITLE
Add basic http request for repositories for an organization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ gloo = "0.6.0"
 yew-router = "0.16.0"
 wasm-bindgen = "0.2.81"
 wasm-bindgen-futures = "0.4"
+chrono = { version = "0.4", features = [ "serde" ] }
 
 [dependencies.web-sys]
 version = "0.3.56"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 yew = "0.19"
 serde = { version = "1.0.117", features = ["derive"] }
+serde_json = "1.0"
 reqwasm = "0.5.0"
 gloo = "0.6.0"
 yew-router = "0.16.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,12 @@ edition = "2021"
 
 [dependencies]
 yew = "0.19"
-serde = "1.0.117"
-reqwasm = "0.4.1"
+serde = { version = "1.0.117", features = ["derive"] }
+reqwasm = "0.5.0"
 gloo = "0.6.0"
 yew-router = "0.16.0"
 wasm-bindgen = "0.2.81"
+wasm-bindgen-futures = "0.4"
 
 [dependencies.web-sys]
 version = "0.3.56"

--- a/Trunk.toml
+++ b/Trunk.toml
@@ -28,3 +28,9 @@ command_arguments = [
 
 [[proxy]]
 backend = "https://yew.rs/tutorial"
+
+[[proxy]]
+backend = "https://jsonplaceholder.typicode.com/posts"
+
+[[proxy]]
+backend = "https://api.github.com/orgs/"

--- a/Trunk.toml
+++ b/Trunk.toml
@@ -25,3 +25,6 @@ command_arguments = [
     "-c",
     "[ ! -d \"./node_modules\" ] && npm i || :; npm run build_css",
 ]
+
+[[proxy]]
+backend = "https://yew.rs/tutorial"

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,7 +141,6 @@ pub fn repository_list(props: &RepositoryListProps) -> Html {
         let organization = organization.clone();
         use_effect_with_deps(move |organization| {
             web_sys::console::log_1(&format!("use_effect_with_deps called with organization {}.", organization).into());
-            repositories.set(vec![]);
             let organization = organization.clone();
             wasm_bindgen_futures::spawn_local(async move {
                 web_sys::console::log_1(&format!("spawn_local called with organization {}.", organization).into());
@@ -215,7 +214,7 @@ fn home_page() -> Html {
             if !organization.is_empty() {
                 <div>
                     <h2 class="text-2xl">{ format!("The list of repositories for the organization {}", (*organization).clone()) }</h2>
-                    <RepositoryList organization={(*organization).clone()} />
+                    <RepositoryList key={(*organization).clone()} organization={(*organization).clone()} />
                 </div>
             }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -131,16 +131,19 @@ pub struct RepositoryListProps {
 
 // Why does `use_effect_with_deps` only execute once?
 
+// Do something about paging.
+
 #[function_component(RepositoryList)]
 pub fn repository_list(props: &RepositoryListProps) -> Html {
     let RepositoryListProps { organization } = props;
-    let organization = organization.clone();
     web_sys::console::log_1(&format!("RepositoryList called with organization {}.", organization).into());
     let repositories = use_state(|| vec![]);
     {
         let repositories = repositories.clone();
-        use_effect_with_deps(move |_| {
+        let organization = organization.clone();
+        use_effect_with_deps(move |organization| {
             web_sys::console::log_1(&format!("use_effect_with_deps called with organization {}.", organization).into());
+            let organization = organization.clone();
             wasm_bindgen_futures::spawn_local(async move {
                 web_sys::console::log_1(&format!("spawn_local called with organization {}.", organization).into());
                 let request_url = format!("/orgs/{org}/repos?sort=pushed&direction=asc", 
@@ -150,7 +153,7 @@ pub fn repository_list(props: &RepositoryListProps) -> Html {
                 repositories.set(repos_result);
             });
             || ()
-        }, ());
+        }, organization);
     }
 
     repositories.iter()

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,18 +125,24 @@ pub struct RepositoryListProps {
 //  * Turn list of repositories into a checkbox list
 
 // Make sure I understand why we need an inner block in `repository_list`.
-// Why do we clone `repositories` twice?
+// Why do we clone `repositories` twice? Ditto for `organization`.
+
+// Why does `use_effect_with_deps` only execute once?
 
 #[function_component(RepositoryList)]
 pub fn repository_list(props: &RepositoryListProps) -> Html {
+    let RepositoryListProps { organization } = props;
+    let organization = organization.clone();
+    web_sys::console::log_1(&format!("RepositoryList called with organization {}.", organization).into());
     let repositories = use_state(|| vec![]);
     {
         let repositories = repositories.clone();
         use_effect_with_deps(move |_| {
-            let repositories = repositories.clone();
+            web_sys::console::log_1(&format!("use_effect_with_deps called with organization {}.", organization).into());
             wasm_bindgen_futures::spawn_local(async move {
+                web_sys::console::log_1(&format!("spawn_local called with organization {}.", organization).into());
                 let request_url = format!("/orgs/{org}/repos", 
-                                                    org="UMM-CSci-3601-S20");
+                                                    org=organization);
                 let response = Request::get(&request_url).send().await.unwrap();
                 let repos_result: Vec<Repository> = response.json().await.unwrap();
                 repositories.set(repos_result);


### PR DESCRIPTION
This gets the basic HTTP request working. The user can enter an organization, and this will get the list of repositories for that organization from GitHub via their REST API and display it.

There are still issues (the UI is ugly, there's no meaningful error handling), but it's a start. We'll need to sort out authentication before we can do much more with the GitHub side of things.