### PR TITLE
Work on pagination

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,7 @@ yew-router = "0.16.0"
 wasm-bindgen = "0.2.81"
 wasm-bindgen-futures = "0.4"
 chrono = { version = "0.4", features = [ "serde" ] }
-regex = "1.6.0"
-once_cell = "1.13.0"
+url = "2.2.2"
 
 [dependencies.web-sys]
 version = "0.3.56"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ wasm-bindgen = "0.2.81"
 wasm-bindgen-futures = "0.4"
 chrono = { version = "0.4", features = [ "serde" ] }
 regex = "1.6.0"
+once_cell = "1.13.0"
 
 [dependencies.web-sys]
 version = "0.3.56"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ yew-router = "0.16.0"
 wasm-bindgen = "0.2.81"
 wasm-bindgen-futures = "0.4"
 chrono = { version = "0.4", features = [ "serde" ] }
+regex = "1.6.0"
 
 [dependencies.web-sys]
 version = "0.3.56"

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,20 +160,20 @@ pub struct RepositoryPaginatorState {
 
 #[derive(Debug)]
 enum LinkParseError {
-    UrlParseError(ParseError),
-    PageEntryMissingError(Url),
-    PageNumParseError(ParseIntError)
+    InvalidUrl(ParseError),
+    PageEntryMissing(Url),
+    InvalidPageNumber(ParseIntError)
 }
 
 impl From<ParseError> for LinkParseError {
     fn from(e: ParseError) -> Self {
-        Self::UrlParseError(e)
+        Self::InvalidUrl(e)
     }
 }
 
 impl From<ParseIntError> for LinkParseError {
     fn from(e: ParseIntError) -> Self {
-        Self::PageNumParseError(e)
+        Self::InvalidPageNumber(e)
     }
 }
 
@@ -206,7 +206,7 @@ fn parse_last_page(link_str: &str) -> Result<Option<usize>, LinkParseError> {
         // and we'll return a LinkParseError::PageEntryMissingError if it happens.
         .find(|(k, _)| k.eq("page"))
         .map(|(_, v)| v)
-        .ok_or_else(|| LinkParseError::PageEntryMissingError(last_url.clone()))?;
+        .ok_or_else(|| LinkParseError::PageEntryMissing(last_url.clone()))?;
     // This fails and returns a LinkParseError::PageNumberParseError if for some
     // reason the `num_pages_str` can't be parsed to a `usize`. This would also
     // presumably be an error or major API change on the part of GitHub.

--- a/src/main.rs
+++ b/src/main.rs
@@ -232,7 +232,7 @@ pub fn repository_paginator(props: &RepositoryPaginatorProps) -> Html {
     }
 
     let RepositoryPaginatorProps { organization } = props;
-    web_sys::console::log_1(&format!("RepositoryPaginator called with organization {}.", organization).into());
+    web_sys::console::log_1(&format!("RepositoryPaginator called with organization {organization}.").into());
     let repository_paginator_state = use_state(|| RepositoryPaginatorState {
         repositories: vec![],
         current_page: 1,
@@ -243,22 +243,22 @@ pub fn repository_paginator(props: &RepositoryPaginatorProps) -> Html {
         let organization = organization.clone();
         let current_page = repository_paginator_state.current_page;
         use_effect_with_deps(move |(organization, current_page)| {
-            web_sys::console::log_1(&format!("use_effect_with_deps called with organization {}.", organization).into());
+            web_sys::console::log_1(&format!("use_effect_with_deps called with organization {organization}.").into());
             let organization = organization.clone();
             let current_page = *current_page;
             wasm_bindgen_futures::spawn_local(async move {
-                web_sys::console::log_1(&format!("spawn_local called with organization {}.", organization).into());
+                web_sys::console::log_1(&format!("spawn_local called with organization {organization}.").into());
                 let request_url = format!("/orgs/{organization}/repos?sort=pushed&direction=asc&per_page=5&page={current_page}");
                 let response = Request::get(&request_url).send().await.unwrap();
                 let link = response.headers().get("link");
-                web_sys::console::log_1(&format!("The link element of the header was <{:?}>.", link).into());
+                web_sys::console::log_1(&format!("The link element of the header was <{link:?}>.").into());
                 let repos_result: Vec<Repository> = response.json().await.unwrap();
                 let repo_state = RepositoryPaginatorState {
                     repositories: repos_result,
                     current_page: 1,
                     last_page: link.as_deref().map_or(1, parse_last_page)
                 };
-                web_sys::console::log_1(&format!("The new repo state is <{:?}>.", repo_state).into());
+                web_sys::console::log_1(&format!("The new repo state is <{repo_state:?}>.").into());
                 repository_paginator_state.set(repo_state);
             });
             || ()
@@ -313,7 +313,7 @@ fn home_page() -> Html {
         let organization = organization.clone();
         Callback::from(move |string| { 
             organization.set(string);
-            // web_sys::console::log_1(&format!("We got <{}> from the text input!", string).into()) 
+            // web_sys::console::log_1(&format!("We got <{string}> from the text input!").into()) 
         })
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -333,6 +333,12 @@ pub fn repository_paginator(props: &RepositoryPaginatorProps) -> Html {
                         Err(err) => { handle_parse_error(&err); return }
                     }
                 };
+                // TODO: This seems fairly slow when there are a lot of repositories. My guess
+                // is that parsing the huge pile of JSON we get back is at least part of the
+                // problem. Switching to GraphQL would potentially help this by allowing us to
+                // specify the exact info we need for each repository (which is a tiny subset of
+                // what GitHub currently provides), which should greatly reduce the
+                // size of the JSON package and the cost of the parsing.
                 let repos_result: Vec<Repository> = response.json().await.unwrap();
                 let repo_state = RepositoryPaginatorState {
                     repositories: repos_result,

--- a/src/main.rs
+++ b/src/main.rs
@@ -258,6 +258,9 @@ fn repository_list(props: &RepositoryListProps) -> Html {
     }
 }
 
+// The GitHub default is 30; they allow no more than 100.
+const REPOS_PER_PAGE: u8 = 5;
+
 // This component has gotten _really_ long. At a minimum it should be moved
 // into its own file. It's also possible that it should be converted into
 // a struct component to help avoid some of the function call/return issues
@@ -313,7 +316,7 @@ pub fn repository_paginator(props: &RepositoryPaginatorProps) -> Html {
             let current_page = *current_page;
             wasm_bindgen_futures::spawn_local(async move {
                 web_sys::console::log_1(&format!("spawn_local called with organization {organization}.").into());
-                let request_url = format!("/orgs/{organization}/repos?sort=pushed&direction=asc&per_page=5&page={current_page}");
+                let request_url = format!("/orgs/{organization}/repos?sort=pushed&direction=asc&per_page={REPOS_PER_PAGE}&page={current_page}");
                 let response = Request::get(&request_url).send().await.unwrap();
                 let link = response.headers().get("link");
                 web_sys::console::log_1(&format!("The link element of the header was <{link:?}>.").into());

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,10 +160,7 @@ pub struct RepositoryPaginatorState {
  * 
  * <https://api.github.com/organizations/18425666/repos?page=1&per_page=5>; rel="prev", <https://api.github.com/organizations/18425666/repos?page=3&per_page=5>; rel="next", <https://api.github.com/organizations/18425666/repos?page=5&per_page=5>; rel="last", <https://api.github.com/organizations/18425666/repos?page=1&per_page=5>; rel="first"
  */
-// TODO: I'd like to bring `link_str` back to being `&str` instead of `String`,
-// but that doesn't work if I use `parse_last_page` directly as an argument in
-// `map_or` in the `repository_list()` function below.
-fn parse_last_page(link_str: String) -> usize {
+fn parse_last_page(link_str: &str) -> usize {
     // TODO: Should I construct this regex somewhere more "global" so it's no reconstructed every time
     // this function is called?
     let re = Regex::new(r#"page=(\d+).*rel="last""#).expect("Constructing the regex for the link text failed");
@@ -246,7 +243,7 @@ pub fn repository_paginator(props: &RepositoryPaginatorProps) -> Html {
                 let repo_state = RepositoryPaginatorState {
                     repositories: repos_result,
                     current_page: 1,
-                    last_page: link.map_or(1, parse_last_page)
+                    last_page: link.as_deref().map_or(1, parse_last_page)
                 };
                 web_sys::console::log_1(&format!("The new repo state is <{:?}>.", repo_state).into());
                 repository_paginator_state.set(repo_state);

--- a/src/main.rs
+++ b/src/main.rs
@@ -262,7 +262,7 @@ fn repository_list(props: &RepositoryListProps) -> Html {
 }
 
 // The GitHub default is 30; they allow no more than 100.
-const REPOS_PER_PAGE: u8 = 5;
+const REPOS_PER_PAGE: u8 = 7;
 
 // This component has gotten _really_ long. At a minimum it should be moved
 // into its own file. It's also possible that it should be converted into
@@ -278,6 +278,7 @@ pub fn repository_paginator(props: &RepositoryPaginatorProps) -> Html {
         Callback::from(move |_| {
             // Only make a new state if the page_number is different than the current_page number.
             if page_number == repository_paginator_state.current_page { return }
+
             let repo_state = RepositoryPaginatorState {
                 repositories: vec![],
                 current_page: page_number,
@@ -335,7 +336,7 @@ pub fn repository_paginator(props: &RepositoryPaginatorProps) -> Html {
                 let repos_result: Vec<Repository> = response.json().await.unwrap();
                 let repo_state = RepositoryPaginatorState {
                     repositories: repos_result,
-                    current_page: 1,
+                    current_page,
                     // I'm increasingly wondering if Yew contexts are the right way to handle all this.
                     last_page
                 };

--- a/src/main.rs
+++ b/src/main.rs
@@ -241,13 +241,14 @@ pub fn repository_paginator(props: &RepositoryPaginatorProps) -> Html {
     {
         let repository_paginator_state = repository_paginator_state.clone();
         let organization = organization.clone();
-        use_effect_with_deps(move |organization| {
+        let current_page = repository_paginator_state.current_page;
+        use_effect_with_deps(move |(organization, current_page)| {
             web_sys::console::log_1(&format!("use_effect_with_deps called with organization {}.", organization).into());
             let organization = organization.clone();
+            let current_page = *current_page;
             wasm_bindgen_futures::spawn_local(async move {
                 web_sys::console::log_1(&format!("spawn_local called with organization {}.", organization).into());
-                let request_url = format!("/orgs/{org}/repos?sort=pushed&direction=asc&per_page=5", 
-                                                    org=organization);
+                let request_url = format!("/orgs/{organization}/repos?sort=pushed&direction=asc&per_page=5&page={current_page}");
                 let response = Request::get(&request_url).send().await.unwrap();
                 let link = response.headers().get("link");
                 web_sys::console::log_1(&format!("The link element of the header was <{:?}>.", link).into());
@@ -261,7 +262,7 @@ pub fn repository_paginator(props: &RepositoryPaginatorProps) -> Html {
                 repository_paginator_state.set(repo_state);
             });
             || ()
-        }, organization);
+        }, (organization, current_page));
     }
 
     html! {

--- a/src/main.rs
+++ b/src/main.rs
@@ -206,11 +206,7 @@ fn parse_last_page(link_str: &str) -> Result<Option<usize>, LinkParseError> {
         // and we'll return a LinkParseError::PageEntryMissingError if it happens.
         .find(|(k, _)| k.eq("page"))
         .map(|(_, v)| v)
-        // The following line fails because of an ownership issue. I think that
-        // we're passing ownership of into the closure, but num_pages_str still
-        // points into that and we need to use that in the line after. I suspect
-        // I'll need to clone something.
-        .ok_or_else(|| LinkParseError::PageEntryMissingError(last_url))?;
+        .ok_or_else(|| LinkParseError::PageEntryMissingError(last_url.clone()))?;
     // This fails and returns a LinkParseError::PageNumberParseError if for some
     // reason the `num_pages_str` can't be parsed to a `usize`. This would also
     // presumably be an error or major API change on the part of GitHub.

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@
 // #![warn(clippy::expect_used)]
 
 use std::collections::HashMap;
+use once_cell::sync::Lazy;
 
 use chrono::DateTime;
 use chrono::Local;
@@ -150,8 +151,6 @@ pub struct RepositoryPaginatorState {
 //  * Do something sensible about error handling
 //  * Turn list of repositories into a checkbox list
 
-// Do something about paging.
-
 /*
  * This parses the `last` component of the link field in the response header from
  * GitHub, which tells us how many pages there are.
@@ -161,10 +160,9 @@ pub struct RepositoryPaginatorState {
  * <https://api.github.com/organizations/18425666/repos?page=1&per_page=5>; rel="prev", <https://api.github.com/organizations/18425666/repos?page=3&per_page=5>; rel="next", <https://api.github.com/organizations/18425666/repos?page=5&per_page=5>; rel="last", <https://api.github.com/organizations/18425666/repos?page=1&per_page=5>; rel="first"
  */
 fn parse_last_page(link_str: &str) -> usize {
-    // TODO: Should I construct this regex somewhere more "global" so it's no reconstructed every time
-    // this function is called?
-    let re = Regex::new(r#"page=(\d+).*rel="last""#).expect("Constructing the regex for the link text failed");
-    let captures = re.captures(link_str).expect("Applying the regex to the link text failed");
+    static RE: Lazy<Regex> = Lazy::new(|| Regex::new(r#"page=(\d+).*rel="last""#).unwrap());
+
+    let captures = RE.captures(link_str).expect("Applying the regex to the link text failed");
     web_sys::console::log_1(&format!("Our capture was <{}>.", &captures[1]).into());
     captures[1].parse::<usize>().expect("Failed to parse last page number from link text")
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -146,6 +146,9 @@ pub struct RepositoryPaginatorProps {
 
 #[derive(Debug)]
 pub struct RepositoryPaginatorState {
+    // TODO: This should probably be an Option<Vec<Repository>> to distinguish between
+    // an organization that has no repositories vs. we're waiting for repositories to
+    // be loaded.
     repositories: Vec<Repository>,
     current_page: usize,
     last_page: usize,
@@ -273,6 +276,8 @@ pub fn repository_paginator(props: &RepositoryPaginatorProps) -> Html {
 
     fn make_button_callback(page_number: usize, repository_paginator_state: UseStateHandle<RepositoryPaginatorState>) -> Callback<MouseEvent> {
         Callback::from(move |_| {
+            // Only make a new state if the page_number is different than the current_page number.
+            if page_number == repository_paginator_state.current_page { return }
             let repo_state = RepositoryPaginatorState {
                 repositories: vec![],
                 current_page: page_number,
@@ -345,23 +350,16 @@ pub fn repository_paginator(props: &RepositoryPaginatorProps) -> Html {
         <>
             if repository_paginator_state.last_page > 1 {
                 <div class="btn-group">
-                {
-                    // Not sure why we need the containing pair of curly braces, but
-                    // it's probably because we're inside an `html!` macro call. I
-                    // might be able to remove the outer `html!` and add the `RepositoryList`
-                    // component call to this iterator in some fashion.
-                    //
-                    // It's possible that `html_nested` would be a useful tool here.
-                    // https://docs.rs/yew/latest/yew/macro.html_nested.html
-                    (1..=repository_paginator_state.last_page).map(|page_number| {
+                // It's possible that `html_nested` would be a useful tool here.
+                // https://docs.rs/yew/latest/yew/macro.html_nested.html
+                {(1..=repository_paginator_state.last_page).map(|page_number| {
                         html! {
                             <button class={ paginator_button_class(page_number, repository_paginator_state.current_page) }
                                     onclick={ make_button_callback(page_number, repository_paginator_state.clone()) }>
                                 { page_number }
                             </button>
                         }
-                    }).collect::<Html>()
-                }
+                    }).collect::<Html>()}
                 </div>
             }
             // TODO: I don't like this .clone(), but passing references got us into lifetime hell.

--- a/src/main.rs
+++ b/src/main.rs
@@ -135,12 +135,12 @@ struct Repository {
 }
 
 #[derive(Clone, PartialEq, Properties)]
-pub struct RepositoryListProps {
+pub struct RepositoryPaginatorProps {
     pub organization: String,
 }
 
 #[derive(Debug)]
-pub struct RepositoryListState {
+pub struct RepositoryPaginatorState {
     repositories: Vec<Repository>,
     current_page: usize,
     last_page: usize,
@@ -181,17 +181,20 @@ fn parse_last_page(link_str: String) -> usize {
  *   - Request the correct page
  */
 
-#[function_component(RepositoryList)]
-pub fn repository_list(props: &RepositoryListProps) -> Html {
-    let RepositoryListProps { organization } = props;
-    web_sys::console::log_1(&format!("RepositoryList called with organization {}.", organization).into());
-    let repository_list_state = use_state(|| RepositoryListState {
+// #[function_component(RepositoryListDisplay)]
+// pub 
+
+#[function_component(RepositoryPaginator)]
+pub fn repository_paginator(props: &RepositoryPaginatorProps) -> Html {
+    let RepositoryPaginatorProps { organization } = props;
+    web_sys::console::log_1(&format!("RepositoryPaginator called with organization {}.", organization).into());
+    let repository_paginator_state = use_state(|| RepositoryPaginatorState {
         repositories: vec![],
         current_page: 1,
         last_page: 0 // This is "wrong" and needs to be set after we've gotten our response.
     });
     {
-        let repository_list_state = repository_list_state.clone();
+        let repository_paginator_state = repository_paginator_state.clone();
         let organization = organization.clone();
         use_effect_with_deps(move |organization| {
             web_sys::console::log_1(&format!("use_effect_with_deps called with organization {}.", organization).into());
@@ -204,24 +207,24 @@ pub fn repository_list(props: &RepositoryListProps) -> Html {
                 let link = response.headers().get("link");
                 web_sys::console::log_1(&format!("The link element of the header was <{:?}>.", link).into());
                 let repos_result: Vec<Repository> = response.json().await.unwrap();
-                let repo_state = RepositoryListState {
+                let repo_state = RepositoryPaginatorState {
                     repositories: repos_result,
                     current_page: 1,
                     last_page: link.map_or(1, parse_last_page)
                 };
                 web_sys::console::log_1(&format!("The new repo state is <{:?}>.", repo_state).into());
-                repository_list_state.set(repo_state);
+                repository_paginator_state.set(repo_state);
             });
             || ()
         }, organization);
     }
 
-    if repository_list_state.repositories.is_empty() {
+    if repository_paginator_state.repositories.is_empty() {
         html! {
             <p>{ "Loading…" }</p>
         }
     } else {
-        repository_list_state.repositories.iter()
+        repository_paginator_state.repositories.iter()
                     .map(|repository: &Repository| {
             html! {
                 <div>
@@ -283,7 +286,7 @@ fn home_page() -> Html {
             if !organization.is_empty() {
                 <div>
                     <h2 class="text-2xl">{ format!("The list of repositories for the organization {}", (*organization).clone()) }</h2>
-                    <RepositoryList key={(*organization).clone()} organization={(*organization).clone()} />
+                    <RepositoryPaginator key={(*organization).clone()} organization={(*organization).clone()} />
                 </div>
             }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -234,7 +234,7 @@ pub fn repository_paginator(props: &RepositoryPaginatorProps) -> Html {
             let organization = organization.clone();
             wasm_bindgen_futures::spawn_local(async move {
                 web_sys::console::log_1(&format!("spawn_local called with organization {}.", organization).into());
-                let request_url = format!("/orgs/{org}/repos?sort=pushed&direction=asc", 
+                let request_url = format!("/orgs/{org}/repos?sort=pushed&direction=asc&per_page=5", 
                                                     org=organization);
                 let response = Request::get(&request_url).send().await.unwrap();
                 let link = response.headers().get("link");
@@ -253,8 +253,27 @@ pub fn repository_paginator(props: &RepositoryPaginatorProps) -> Html {
     }
 
     html! {
-        // TODO: I don't like this .clone(), but passing references got us into lifetime hell.
-        <RepositoryList repositories={ repository_paginator_state.repositories.clone() } />
+        <>
+            if repository_paginator_state.last_page > 0 {
+                <div class="btn-group">
+                {
+                    // Not sure why we need the containing pair of curly braces, but
+                    // it's probably because we're inside an `html!` macro call. I
+                    // might be able to remove the outer `html!` and add the `RepositoryList`
+                    // component call to this iterator in some fashion.
+                    (1..repository_paginator_state.last_page+1).map(|page_number| {
+                        html! {
+                            <button class={ if page_number == repository_paginator_state.current_page { "btn btn-active" } else { "btn" }}>
+                                { page_number }
+                            </button>
+                        }
+                    }).collect::<Html>()
+                }
+                </div>
+            }
+            // TODO: I don't like this .clone(), but passing references got us into lifetime hell.
+            <RepositoryList repositories={ repository_paginator_state.repositories.clone() } />
+        </>
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -181,8 +181,44 @@ fn parse_last_page(link_str: String) -> usize {
  *   - Request the correct page
  */
 
-// #[function_component(RepositoryListDisplay)]
-// pub 
+#[derive(Clone, PartialEq, Properties)]
+pub struct RepositoryListProps {
+    repositories: Vec<Repository>
+}
+
+#[function_component(RepositoryList)]
+pub fn repository_list(props: &RepositoryListProps) -> Html {
+    let RepositoryListProps { repositories } = props;
+    if repositories.is_empty() {
+        html! {
+            <p>{ "Loading…" }</p>
+        }
+    } else {
+        repositories.iter()
+                    .map(|repository: &Repository| {
+            html! {
+                <div>
+                    if repository.archived {
+                        <h2 class="text-2xl text-gray-300">{ repository.name.clone() }</h2>
+                    } else {
+                        <h2 class="text-2xl">{ repository.name.clone() }</h2>
+                    }
+                    if let Some(description) = &repository.description {
+                        <p class="text-green-700">{ 
+                            description.clone() 
+                        }</p>
+                    } else {
+                        <p class="text-blue-700">{
+                            "There was no description for this repository"
+                        }</p>
+                    }
+                    <p>{ format!("Last updated on {}", repository.updated_at.clone().format("%Y-%m-%d")) }</p>
+                    <p>{ format!("Last pushed to on {}", repository.pushed_at.clone().format("%Y-%m-%d")) }</p>
+                </div>
+            }
+        }).collect()
+    }
+}
 
 #[function_component(RepositoryPaginator)]
 pub fn repository_paginator(props: &RepositoryPaginatorProps) -> Html {
@@ -219,34 +255,9 @@ pub fn repository_paginator(props: &RepositoryPaginatorProps) -> Html {
         }, organization);
     }
 
-    if repository_paginator_state.repositories.is_empty() {
-        html! {
-            <p>{ "Loading…" }</p>
-        }
-    } else {
-        repository_paginator_state.repositories.iter()
-                    .map(|repository: &Repository| {
-            html! {
-                <div>
-                    if repository.archived {
-                        <h2 class="text-2xl text-gray-300">{ repository.name.clone() }</h2>
-                    } else {
-                        <h2 class="text-2xl">{ repository.name.clone() }</h2>
-                    }
-                    if let Some(description) = &repository.description {
-                        <p class="text-green-700">{ 
-                            description.clone() 
-                        }</p>
-                    } else {
-                        <p class="text-blue-700">{
-                            "There was no description for this repository"
-                        }</p>
-                    }
-                    <p>{ format!("Last updated on {}", repository.updated_at.clone().format("%Y-%m-%d")) }</p>
-                    <p>{ format!("Last pushed to on {}", repository.pushed_at.clone().format("%Y-%m-%d")) }</p>
-                </div>
-            }
-        }).collect()
+    html! {
+        // TODO: I don't like this .clone(), but passing references got us into lifetime hell.
+        <RepositoryList repositories={ repository_paginator_state.repositories.clone() } />
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -214,6 +214,23 @@ fn repository_list(props: &RepositoryListProps) -> Html {
 
 #[function_component(RepositoryPaginator)]
 pub fn repository_paginator(props: &RepositoryPaginatorProps) -> Html {
+    fn paginator_button_class(page_number: usize, current_page: usize) -> String {
+        if page_number == current_page { "btn btn-active".to_string() } else { "btn".to_string() }
+    }
+
+    fn make_button_callback(page_number: usize, repository_paginator_state: UseStateHandle<RepositoryPaginatorState>) -> Callback<MouseEvent> {
+        Callback::from(move |_| {
+            let repo_state = RepositoryPaginatorState {
+                repositories: vec![],
+                current_page: page_number,
+                last_page: repository_paginator_state.last_page
+            };
+            web_sys::console::log_1(&format!("make_button_callback called with page number {page_number}.").into());
+            web_sys::console::log_1(&format!("New state is {repo_state:?}.").into());
+            repository_paginator_state.set(repo_state);
+        })
+    }
+
     let RepositoryPaginatorProps { organization } = props;
     web_sys::console::log_1(&format!("RepositoryPaginator called with organization {}.", organization).into());
     let repository_paginator_state = use_state(|| RepositoryPaginatorState {
@@ -256,9 +273,13 @@ pub fn repository_paginator(props: &RepositoryPaginatorProps) -> Html {
                     // it's probably because we're inside an `html!` macro call. I
                     // might be able to remove the outer `html!` and add the `RepositoryList`
                     // component call to this iterator in some fashion.
+                    //
+                    // It's possible that `html_nested` would be a useful tool here.
+                    // https://docs.rs/yew/latest/yew/macro.html_nested.html
                     (1..=repository_paginator_state.last_page).map(|page_number| {
                         html! {
-                            <button class={ if page_number == repository_paginator_state.current_page { "btn btn-active" } else { "btn" }}>
+                            <button class={ paginator_button_class(page_number, repository_paginator_state.current_page) }
+                                    onclick={ make_button_callback(page_number, repository_paginator_state.clone()) }>
                                 { page_number }
                             </button>
                         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,7 +160,7 @@ pub struct RepositoryPaginatorState {
  * <https://api.github.com/organizations/18425666/repos?page=1&per_page=5>; rel="prev", <https://api.github.com/organizations/18425666/repos?page=3&per_page=5>; rel="next", <https://api.github.com/organizations/18425666/repos?page=5&per_page=5>; rel="last", <https://api.github.com/organizations/18425666/repos?page=1&per_page=5>; rel="first"
  */
 fn parse_last_page(link_str: &str) -> usize {
-    static RE: Lazy<Regex> = Lazy::new(|| Regex::new(r#"page=(\d+).*rel="last""#).unwrap());
+    static RE: Lazy<Regex> = Lazy::new(|| Regex::new(r#"[&?]page=(\d+).*rel="last""#).unwrap());
 
     let captures = RE.captures(link_str).expect("Applying the regex to the link text failed");
     web_sys::console::log_1(&format!("Our capture was <{}>.", &captures[1]).into());
@@ -249,7 +249,7 @@ pub fn repository_paginator(props: &RepositoryPaginatorProps) -> Html {
 
     html! {
         <>
-            if repository_paginator_state.last_page > 0 {
+            if repository_paginator_state.last_page > 1 {
                 <div class="btn-group">
                 {
                     // Not sure why we need the containing pair of curly braces, but

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,11 @@ fn get_value_from_input_event(e: InputEvent) -> String {
 // * Allow the user to press "Enter" instead of having to click on "Submit"
 // * Convert the state back to &str to avoid all the copying.
 //   * Maybe going to leave this alone? We got into a lot of lifetime issues that I didn't
-//     want to deal with right now.
+//     want to deal with right now., because with the current version of Yew (v19), we can't
+//     add generics to function components, and we'd need a lifetime component on the
+//     properties, which bleeds through to the function component.
+//   * Generics on function components have been added in the next version of Yew, so
+//     we can come back to this if/when I upgrade to the newer version.
 // * Deal with paging from GitHub
 
 /// Controlled Text Input Component
@@ -147,7 +151,8 @@ pub struct RepositoryPaginatorState {
     last_page: usize,
 }
 
-// Things to work on, 30 July 2022
+// Things to work on, 13 August 2022
+//  * Fix the problem with my regex for the pagination, probably by replacing the regex.
 //  * Do something sensible about error handling
 //  * Turn list of repositories into a checkbox list
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 #![warn(clippy::pedantic)]
 #![warn(clippy::nursery)]
-#![warn(clippy::unwrap_used)]
-#![warn(clippy::expect_used)]
+// #![warn(clippy::unwrap_used)]
+// #![warn(clippy::expect_used)]
 
 use std::collections::HashMap;
 
@@ -164,7 +164,7 @@ fn parse_last_page(link_str: &str) -> usize {
     // TODO: Should I construct this regex somewhere more "global" so it's no reconstructed every time
     // this function is called?
     let re = Regex::new(r#"page=(\d+).*rel="last""#).expect("Constructing the regex for the link text failed");
-    let captures = re.captures(&link_str).expect("Applying the regex to the link text failed");
+    let captures = re.captures(link_str).expect("Applying the regex to the link text failed");
     web_sys::console::log_1(&format!("Our capture was <{}>.", &captures[1]).into());
     captures[1].parse::<usize>().expect("Failed to parse last page number from link text")
 }
@@ -179,12 +179,12 @@ fn parse_last_page(link_str: &str) -> usize {
  */
 
 #[derive(Clone, PartialEq, Properties)]
-pub struct RepositoryListProps {
+struct RepositoryListProps {
     repositories: Vec<Repository>
 }
 
 #[function_component(RepositoryList)]
-pub fn repository_list(props: &RepositoryListProps) -> Html {
+fn repository_list(props: &RepositoryListProps) -> Html {
     let RepositoryListProps { repositories } = props;
     if repositories.is_empty() {
         html! {
@@ -200,14 +200,11 @@ pub fn repository_list(props: &RepositoryListProps) -> Html {
                     } else {
                         <h2 class="text-2xl">{ repository.name.clone() }</h2>
                     }
-                    if let Some(description) = &repository.description {
-                        <p class="text-green-700">{ 
-                            description.clone() 
-                        }</p>
-                    } else {
-                        <p class="text-blue-700">{
-                            "There was no description for this repository"
-                        }</p>
+                    {
+                        repository.description.as_ref().map_or_else(
+                            || html! { <p class="text-blue-700">{ "There was no description for this repository "}</p> },
+                            |s| html! { <p class="text-green-700">{ s.clone() }</p> }
+                        )
                     }
                     <p>{ format!("Last updated on {}", repository.updated_at.clone().format("%Y-%m-%d")) }</p>
                     <p>{ format!("Last pushed to on {}", repository.pushed_at.clone().format("%Y-%m-%d")) }</p>
@@ -261,7 +258,7 @@ pub fn repository_paginator(props: &RepositoryPaginatorProps) -> Html {
                     // it's probably because we're inside an `html!` macro call. I
                     // might be able to remove the outer `html!` and add the `RepositoryList`
                     // component call to this iterator in some fashion.
-                    (1..repository_paginator_state.last_page+1).map(|page_number| {
+                    (1..=repository_paginator_state.last_page).map(|page_number| {
                         html! {
                             <button class={ if page_number == repository_paginator_state.current_page { "btn btn-active" } else { "btn" }}>
                                 { page_number }


### PR DESCRIPTION
This adds pagination support to the project. We parse the total number of pages from the `link` field in the response headers, and from that we can populate a DaisyUI component to display the page options. We also have to save the current page in the `RepositoryListState` and request the correct page when the user clicks on one of the pagination buttons.

This doesn't yet work, but it's a solid start on adding pagination of repositories.

We've had to expand the state of the `RepositoryList` component to include the current and last page numbers.

The last page number should be parseable from the `link` field in the response header, but that's not yet fully working. I tried using regex and got close but not quite there. @esitsu from Twitch suggested an alternative approach that parses the URLs using the url crate, and I might switch to that.

We restored the display of previously archived repositories because without them the pagination will be all confused. When we get this working, we probably do something to shuffle the archived repos to the end of the list.